### PR TITLE
manifest: Bump ostree, flatpak-builder and flatpak to 0.99.3

### DIFF
--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -681,8 +681,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/ostreedev/ostree/releases/download/v2018.5/libostree-2018.5.tar.xz",
-                    "sha256" : "ad0f5a0e7a7f22f87c72b318b2cfdbe8cf908a1a469ec94eb72984bbb3690261"
+                    "url" : "https://github.com/ostreedev/ostree/releases/download/v2018.6/libostree-2018.6.tar.xz",
+                    "sha256" : "8dd49a1ab94924e351ff9cfd8ea2bf725770400900f4875ad2cc95712c6cc905"
                 }
             ]
         },
@@ -710,8 +710,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/flatpak/flatpak/releases/download/0.11.8.1/flatpak-0.11.8.1.tar.xz",
-                    "sha256" : "9b2356a105da2d0a0332150f5a242a78ca3957f991db5d785c256fdad00cd06a"
+                    "url" : "https://github.com/flatpak/flatpak/releases/download/0.99.3/flatpak-0.99.3.tar.xz",
+                    "sha256" : "d3ab44c8174f9c2b69b09ac630d5d1987bfe529226d7eca6ac1c7d8f438fa671"
                 }
             ]
         },
@@ -720,8 +720,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/flatpak/flatpak-builder/releases/download/0.10.10/flatpak-builder-0.10.10.tar.xz",
-                    "sha256" : "c299985b230cdb052c6b8f8e912fc7e735b1a3868b2e008c49456ee16a160c2c"
+                    "url" : "https://github.com/flatpak/flatpak-builder/releases/download/0.99.3/flatpak-builder-0.99.3.tar.xz",
+                    "sha256" : "93de343e09cc1e929234623e1b241e3a4330e76e7c18cccd3543f13d3ccb036b"
                 }
             ]
         },


### PR DESCRIPTION
Recent releases of flatpak-builder will use HostCommand to execute
flatpak from within the sandbox, enabling us to build flatpaks
from within builder running as a flatpak.

See the discussion on: https://gitlab.gnome.org/GNOME/gnome-builder/merge_requests/76