### PR TITLE
manifest: Bump gnome-builder dep to gnome-builder-2-38 tip

### DIFF
--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -789,7 +789,7 @@
                     "disable-shallow-clone" : true,
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/GNOME/gnome-builder.git",
-                    "branch" : "25fdaa910792cf6994d8cbd6eed72108b27f42ed"
+                    "branch" : "c2ca4dd7830dec6136422fee00c7b190de08d479"
                 }
             ]
         }


### PR DESCRIPTION
This includes some changes we need for Endless, such as the following:

 - https://gitlab.gnome.org/GNOME/gnome-builder/merge_requests/75
 - https://gitlab.gnome.org/GNOME/gnome-builder/merge_requests/78
 - https://gitlab.gnome.org/GNOME/gnome-builder/merge_requests/77