### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -38,8 +38,6 @@
         "-vvvv"
     ],
     "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g",
         "env" : {
             "BASH_COMPLETIONSDIR" : "/app/share/bash-completion/completions",
             "MOUNT_FUSE_PATH" : "../tmp/",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.