### PR TITLE
manifest: Set IDE_BUILD_CHANNEL correctly

### DIFF
--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -629,7 +629,7 @@
                 "-Dpython_libprefix=python3.7",
                 "-Dtracing=true",
                 "-Dhelp=true",
-                "-Dchannel=flatpak-nightly",
+                "-Dchannel=flatpak-stable",
                 "-Dplugin_deviced=true",
                 "-Dplugin_vala=true"
             ],


### PR DESCRIPTION
The About dialog exposes the release channel of Builder. 

The version from Flathub displays "flatpak-nightly", but it should be "flatpak-stable".

Set the meson option accordingly to fix.