### PR TITLE
Update flatpak-builder to 1.4.3

### DIFF
--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -534,7 +534,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/flatpak/flatpak-builder.git",
-                    "tag" : "1.3.5"
+                    "tag" : "1.4.3"
                 }
             ]
         },


### PR DESCRIPTION
This will be required to build apps using 24.08 base runtimes and newer.

https://github.com/flatpak/flatpak-builder/pull/588