### PR TITLE
Update GNOME SDK version from 48 to 50

### DIFF
--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -542,12 +542,19 @@
                     "url": "https://github.com/flatpak/flatpak-builder.git",
                     "tag": "1.4.7",
                     "commit": "a7a5aae277c99b7df068f413ab818854ed5c7af5",
+                    "disable-submodules": true,
                     "x-checker-data": {
                         "type": "git",
                         "is-important": true,
                         "url": "https://github.com/flatpak/flatpak-builder.git",
                         "tag-pattern": "^([\\d]+\\.\\d*[02468][\\d.]*)$"
                     }
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/GNOME/libglnx.git",
+                    "commit": "ccea836b799256420788c463a638ded0636b1632",
+                    "dest": "subprojects/libglnx"
                 }
             ]
         },

--- a/org.gnome.Builder.json
+++ b/org.gnome.Builder.json
@@ -732,7 +732,7 @@
                 "-Dchannel=flatpak-stable",
                 "-Dnetwork_tests=false",
                 "-Dplugin_deviced=true",
-                "-Dgnome_sdk_version=48"
+                "-Dgnome_sdk_version=50"
             ],
             "cleanup": [
                 "/share/gnome-builder/gir-1.0"


### PR DESCRIPTION
Relevant: https://gitlab.gnome.org/GNOME/gnome-builder/-/work_items/2398

GNOME Builder is using an SDK version that was marked EOL in April 2026, but is still automatically downloaded with every new project template creation. If this is the correct variable to modify, I will be more than happy to be regularly updating it with every new stable GNOME SDK, going forward.

(same goes for legacy X11-related arguments, but that's a story for another time)